### PR TITLE
[Beloin](hotfix) Using `popen` to run commands, instead of `vim.cmd`

### DIFF
--- a/launch.nvim
+++ b/launch.nvim
@@ -11,7 +11,8 @@
       "args" : [ "examples/flow-control/example_02.bc" ],
       "env": { 
         "ENV_VAR": "1" 
-      }
+      },
+      "cwd": "."
     }
   ]
 }

--- a/lua/Launch/parser.lua
+++ b/lua/Launch/parser.lua
@@ -95,6 +95,14 @@ local function cache_get_name(table)
 	return table["configurations"][M.__current_index]["name"]
 end
 
+local function cache_get_cwd(table)
+	if not table then
+		return nil
+	end
+
+	return table["configurations"][M.__current_index]["cwd"]
+end
+
 M.load = function()
 	M.__current_table = parse()
 	return M.__current_table
@@ -164,6 +172,10 @@ function M.set_index(i)
 	if M.__current_table then
 		M.__current_index = i
 	end
+end
+
+function M.get_cwd()
+  return cache_get_cwd(M.__current_table)
 end
 
 return M

--- a/lua/Launch/utils.lua
+++ b/lua/Launch/utils.lua
@@ -14,4 +14,16 @@ function M.dump(o)
 	end
 end
 
+function M.run_sh(command)
+	local handle = io.popen(command)
+	if not handle then
+		return false, nil
+	end
+
+	local result = handle:read("*a")
+	handle:close()
+
+	return true, result
+end
+
 return M


### PR DESCRIPTION
- Added Err treatment
- Added `cwd` configuration